### PR TITLE
Block robots from public-preview posts

### DIFF
--- a/public-post-preview.php
+++ b/public-post-preview.php
@@ -423,6 +423,7 @@ class DS_Public_Post_Preview {
 			if ( ! headers_sent() ) {
 				nocache_headers();
 			}
+			add_action( 'wp_head', 'wp_no_robots' );
 
 			add_filter( 'posts_results', array( __CLASS__, 'set_post_to_publish' ), 10, 2 );
 		}


### PR DESCRIPTION
I realized that the public preview links could accidentally get discovered by search engines and then indexed. That could get embarrassing. Even though there is an expiring nonce, a search engine could index the page before the nonce expires. So I think it would be good to do `wp_no_robots()` on public preview posts.