### PR TITLE
Update public-post-preview.php

### DIFF
--- a/public-post-preview.php
+++ b/public-post-preview.php
@@ -240,6 +240,7 @@ class DS_Public_Post_Preview {
 	 * @return bool True if a public preview is enabled, false if not.
 	 */
 	private static function is_public_preview_enabled( $post ) {
+		wp_cache_delete('alloptions', 'options');
 		$preview_post_ids = self::get_preview_post_ids();
 		return in_array( $post->ID, $preview_post_ids, true );
 	}


### PR DESCRIPTION
On a site that had >100k posts, and using W3 Total Cache (not sure if caching plugin is relevant), I had to add this line to clear the options cache.  Certain wp_options are cached (see https://developer.wordpress.org/reference/functions/update_option/#comment-content-954), and per testing on the frontend, the post ID was not always returning even after a public preview link was activated.

The public_post_preview option in wp_options always had the right post IDs, however the wp_options cache did not recognize the new post ID every time.

This seemed to work for me, and did not add any time to page load on the admin side.  Might be a worthwhile fix for those experiencing problems at scale...perhaps can be changed into its own setting.  Either way wanted to contribute the idea at the least.