### PR TITLE
Add a simple composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+  "name": "ocean90/public-post-preview",
+  "description": "WordPress plugin to highlight source code",
+  "type": "wordpress-plugin",
+  "license": "Public domain",
+  "version": "master",
+  "authors": [
+    {
+      "name": "Dominik Schilling"
+    },
+    {
+      "name": "Matt Martz"
+    },
+    {
+      "name": "Jonathan Dingman"
+    }
+  ],
+  "source": {
+      "url": "https://github.com/afrittoli/.git",
+      "type": "git"
+  }
+}


### PR DESCRIPTION
Having a composer.json enables installing the plugin via the
composer tool.