### PR TITLE
Update Grammar for 'The link has been expired!'

### DIFF
--- a/public-post-preview.php
+++ b/public-post-preview.php
@@ -498,7 +498,7 @@ class DS_Public_Post_Preview {
 		}
 
 		if ( ! self::verify_nonce( get_query_var( '_ppp' ), 'public_post_preview_' . $post_id ) ) {
-			wp_die( __( 'The link has been expired!', 'public-post-preview' ) );
+			wp_die( __( 'This link has expired!', 'public-post-preview' ) );
 		}
 
 		if ( ! in_array( $post_id, self::get_preview_post_ids() ) ) {


### PR DESCRIPTION
Hello,

This issue was opened on Meta Trac - https://meta.trac.wordpress.org/ticket/4459

Updating the source here to fix the grammar.

Updated - The link has been expired!
To - This link has expired!

Cheers