### PR TITLE
Direct the user to the public preview of a post when they switch off from the post editing screen

### DIFF
--- a/public-post-preview.php
+++ b/public-post-preview.php
@@ -163,7 +163,7 @@ class DS_Public_Post_Preview {
 	 * @return string The target redirect location.
 	 */
 	public static function user_switching_redirect_to( $redirect_to, $redirect_type, $new_user, $old_user ) {
-		$post_id = intval( $_GET['redirect_to_post'] ?? 0 );
+		$post_id = isset( $_GET['redirect_to_post'] ) ? (int) $_GET['redirect_to_post'] : 0;
 
 		if ( ! $post_id ) {
 			return $redirect_to;

--- a/public-post-preview.php
+++ b/public-post-preview.php
@@ -154,7 +154,7 @@ class DS_Public_Post_Preview {
 	 *
 	 * This is used to direct the user to the public preview of a post when they switch off from the post editing screen.
 	 *
-	 * @since x.y.z
+	 * @since 2.10.0
 	 *
 	 * @param string       $redirect_to   The target redirect location, or an empty string if none is specified.
 	 * @param string|null  $redirect_type The redirect type, see the `user_switching::REDIRECT_*` constants.


### PR DESCRIPTION
I just released version 1.7 of [my User Switching plugin](https://wordpress.org/plugins/user-switching/) which includes a new feature which redirects a user to the post permalink if they use the "Switch Off" feature from the post editing screen. This creates a really nice workflow for checking how a post appears to non-logged-in users.

With both Public Post Preview and User Switching in use, this workflow can be extended to unpublished posts that have a public preview enabled. The change in this PR hooks into the required filter in User Switching 1.7+ and redirects the user to the public post preview if it's enabled.

## To test:

1. Install User Switching version 1.7 or later
2. Edit an unpublished post and enable public preview
3. Click "Switch Off" in the user profile menu in the admin toolbar
4. Verify that you get redirected to the public post preview

After this you can switch back and re-test with a post that does not have public post preview enabled, and confirm you just get redirected to the home page as normal.

What do you think?