### PR TITLE
Sanitize input variables

### DIFF
--- a/public-post-preview.php
+++ b/public-post-preview.php
@@ -331,7 +331,7 @@ class DS_Public_Post_Preview {
 			return false;
 		}
 
-		if ( empty( $_POST['public_post_preview_wpnonce'] ) || ! wp_verify_nonce( $_POST['public_post_preview_wpnonce'], 'public-post-preview_' . $post_id ) ) {
+		if ( empty( $_POST['public_post_preview_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( $_POST['public_post_preview_wpnonce'] ), 'public-post-preview_' . $post_id ) ) {
 			return false;
 		}
 
@@ -434,7 +434,7 @@ class DS_Public_Post_Preview {
 		}
 
 		$preview_post_id = (int) $_POST['post_ID'];
-		$checked         = (string) $_POST['checked'];
+		$checked         = (string) sanitize_text_field( $_POST['checked'] );
 
 		check_ajax_referer( 'public-post-preview_' . $preview_post_id );
 


### PR DESCRIPTION
I did a scan of this plugin with WP VIP minimum security standards, and it did great. Much better than most plugins. 

There were two issues flagged at severity level 10. I looked at the code and currently, these input variables wouldn't lead to an exploitation, but by applying sanitization early, it can prevent a potential vector if the code changes in the future in a way that might have allowed an exploit otherwise.

The security mantra is:
Sanitize early, escape late.