### PR TITLE
Add Restricted Site Access bypass when post has Public Post Preview enabled

### DIFF
--- a/public-post-preview.php
+++ b/public-post-preview.php
@@ -735,6 +735,9 @@ class DS_Public_Post_Preview {
 			add_filter( 'comments_open', '__return_false' );
 			add_filter( 'pings_open', '__return_false' );
 			add_filter( 'wp_link_pages_link', array( __CLASS__, 'filter_wp_link_pages_link' ), 10, 2 );
+
+			// Allow this plugin to work with Restricted Site Access https://wordpress.org/plugins/restricted-site-access/
+			add_action( 'restricted_site_access_is_restricted', '__return_true', 10, 2 );
 		}
 
 		return $posts;


### PR DESCRIPTION
## Changes

When a site uses [Restricted Site Access](https://wordpress.org/plugins/restricted-site-access/) to prevent logged-out users from viewing the site, that plugin prevents Public Post Preview from being used to allow logged-out users to view specific posts. A common scenario where this occurs is when RSA is used to restrict access to a staging or development site, where logged-out users may be needed for reviews or testing. 

This change allows valid PPP links to pierce RSA's restrictions.

I'm filing _this_ PR against PPP, but if this feature is better implemented in RSA, I have a corresponding PR against RSA here: TKTK

## Testing

1. Enable PPP and RSA on the same site.
3. Create a draft post. 
4. Verify that the draft post is visible to logged-in users, and blocked for logged-out users.
5. Enable PPP for the post.
6. Verify that the draft post is visible to both logged-in users and logged-out users.
6. Disable PPP for the post.
7. Verify that the draft post is visible to logged-in users, and blocked for logged-out users.

Questions:

- What's the expected behavior for a former PPP post which has been published but is still behind RSA?
- What's the expected behavior when a PPP post's preview link has expired?
- What other information do you need from third-party contributors?